### PR TITLE
Add state update logic and verify with tests

### DIFF
--- a/chessgpt/rules.py
+++ b/chessgpt/rules.py
@@ -355,19 +355,28 @@ def apply_move(state: State, move: Move) -> None:
             state.castling_rights.discard('q')
         elif move.to_sq == 0 * 8 + 7:
             state.castling_rights.discard('k')
-    # update en passant target
+    mover = state.to_move
+    # en passant square
     if piece.lower() == 'p' and abs(row_to - row_from) == 2:
         ep_row = (row_from + row_to) // 2
-        state.en_passant = ep_row * 8 + col_from
+        state.en_passant = ep_row * 8 + col_to
     else:
         state.en_passant = None
-    # update clocks
+
+    # halfmove clock
     if piece.lower() == 'p' or capture:
         state.halfmove_clock = 0
     else:
         state.halfmove_clock += 1
-    if state.to_move == 'b':
+
+    # fullmove number
+    if mover == 'b':
         state.fullmove_number += 1
+
+    # keep castling rights ordered as set
+    state.castling_rights = {c for c in "KQkq" if c in state.castling_rights}
+
+    # switch side
     state.to_move = opposite(state.to_move)
 
 

--- a/tests/test_state_updates.py
+++ b/tests/test_state_updates.py
@@ -1,0 +1,26 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from chessgpt import Board, rules
+
+
+def test_en_passant_and_halfmove_after_double_push():
+    board = Board()
+    board.make_move(rules.Move.from_uci("e2e4"))
+    assert board.state.en_passant == rules.square_index("e3")
+    assert board.state.halfmove_clock == 0
+
+
+def test_fullmove_increment_after_black_move():
+    board = Board()
+    board.make_move(rules.Move.from_uci("e2e4"))
+    board.make_move(rules.Move.from_uci("e7e5"))
+    assert board.state.fullmove_number == 2
+
+
+def test_king_move_removes_castling_rights():
+    fen = "r3k2r/8/8/8/8/8/8/R3K2R w KQkq - 0 1"
+    board = Board(fen)
+    board.make_move(rules.Move.from_uci("e1e2"))
+    assert "K" not in board.state.castling_rights
+    assert "Q" not in board.state.castling_rights


### PR DESCRIPTION
## Summary
- update `apply_move` to maintain en passant targets, clocks, fullmove count, and side to move
- ensure castling rights remain ordered as a set
- keep tests for en passant, move counters and castling rights

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688778c357e88325bdb86495d8340659